### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/slabs-io/slabs.png?label=ready&title=Ready)](https://waffle.io/slabs-io/slabs)
 [![Build Status](https://api.shippable.com/projects/54774d48d46935d5fbbecc12/badge?branchName=master)](https://app.shippable.com/projects/54774d48d46935d5fbbecc12/builds/latest)
 # Slabs.io
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/slabs-io/slabs

This was requested by a real person (user elliot-a) on waffle.io, we're not trying to spam you.